### PR TITLE
Change buttons to grid from table

### DIFF
--- a/src/lib/et_canvas.adb
+++ b/src/lib/et_canvas.adb
@@ -3036,8 +3036,7 @@ package body et_canvas is
 		box_h0.pack_start (box_v2, expand => false);
 
 
-		gtk_new (buttons_table, rows => 5, columns => 1, 
-			homogeneous => false);
+		gtk_new (buttons_grid);
 		-- table.set_col_spacings (50);
 		-- table_coordinates.set_border_width (10);
 
@@ -3052,33 +3051,27 @@ package body et_canvas is
 		
 
 		
-		-- The table shall not expand downward:
-		box_v2.pack_start (buttons_table, expand => false);
+		-- The grid shall not expand downward:
+		box_v2.pack_start (buttons_grid, expand => false);
 
 		
-		buttons_table.attach (button_zoom_fit,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 0, bottom_attach => 1);
+		buttons_grid.attach (button_zoom_fit,
+			left => 1, top => 1);
 
-		buttons_table.attach (button_zoom_area,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 1, bottom_attach => 2);
+		buttons_grid.attach (button_zoom_area,
+			left => 1, top => 2);
 		
-		buttons_table.attach (button_add,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 2, bottom_attach => 3);
+		buttons_grid.attach (button_add,
+			left => 1, top => 3);
 
-		buttons_table.attach (button_delete,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 3, bottom_attach => 4);
+		buttons_grid.attach (button_delete,
+			left => 1, top => 4);
 
-		buttons_table.attach (button_move,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 4, bottom_attach => 5);
+		buttons_grid.attach (button_move,
+			left => 1, top => 5);
 
-		buttons_table.attach (button_export,
-			left_attach => 0, right_attach => 1,
-			top_attach  => 5, bottom_attach => 6);
+		buttons_grid.attach (button_export,
+			left => 1, top => 6);
 				
 	end create_buttons;	
 

--- a/src/lib/et_canvas.ads
+++ b/src/lib/et_canvas.ads
@@ -65,6 +65,7 @@ with gtk.adjustment;			use gtk.adjustment;
 with gtk.scrollbar;				use gtk.scrollbar;
 
 with gtk.table;					use gtk.table;
+with gtk.grid;					use gtk.grid;
 with gtk.label;					use gtk.label;
 with gtk.button;				use gtk.button;
 with gtk.text_view;				use gtk.text_view;
@@ -1240,7 +1241,7 @@ package et_canvas is
 
 -- BUTTONS:
 
-	buttons_table		: gtk_table;
+	buttons_grid		: gtk_grid;
 	
 	button_zoom_fit		: gtk_button;
 	button_zoom_area	: gtk_button;


### PR DESCRIPTION
Gtk.Table is deprecated resulting in compile warning about use of obsolescent procedure. Gtk.Grid is recommended instead. 