### PR TITLE
Fix redundant conversion

### DIFF
--- a/src/lib/et_canvas-cmd.adb
+++ b/src/lib/et_canvas-cmd.adb
@@ -245,9 +245,9 @@ package body et_canvas.cmd is
 				-- Sets the cursor to a certain place
 				-- but leaves the zoom factor unchanged:
 				procedure set is
-					c : type_vector_model := type_vector_model (set (
+					c : type_vector_model := set (
 						x => to_distance (get_field (5)),
-						y => to_distance (get_field (6))));
+						y => to_distance (get_field (6)));
 
 				begin
 					log (text => "set cursor at " & to_string (c),
@@ -261,9 +261,9 @@ package body et_canvas.cmd is
 				-- Zooms on a given point and places the cursor
 				-- at the given point:
 				procedure zoom_to_point is
-					c : type_vector_model := type_vector_model (set (
+					c : type_vector_model := set (
 						x => to_distance (get_field (5)),
-						y => to_distance (get_field (6))));
+						y => to_distance (get_field (6)));
 
 					l : type_zoom_factor := to_zoom_factor (get_field (7));
 				begin
@@ -366,9 +366,9 @@ package body et_canvas.cmd is
 			procedure move_cursor is
 
 				procedure move is
-					c : type_vector_model := type_vector_model (set (
+					c : type_vector_model := set (
 						x => to_distance (get_field (5)),
-						y => to_distance (get_field (6))));
+						y => to_distance (get_field (6)));
 
 				begin
 					log (text => "move cursor by " & to_string (c),

--- a/src/lib/et_canvas-drawing_frame.adb
+++ b/src/lib/et_canvas-drawing_frame.adb
@@ -236,14 +236,14 @@ package body et_canvas.drawing_frame is
 				
 				-- draw the line bottom-up:
 				-- lower end:
-				set_A (l, type_vector_model (set (
+				set_A (l, set (
 					x => x,
-					y => zero)));
+					y => zero));
 
 				-- upper end:
-				set_B (l, type_vector_model (set (
+				set_B (l, set (
 					x => x,
-					y => b)));
+					y => b));
 
 				draw_line;
 
@@ -252,14 +252,14 @@ package body et_canvas.drawing_frame is
 				-- UPPER BORDER
 				-- draw the line bottom-up:
 				-- lower end:
-				set_A (l, type_vector_model (set (
+				set_A (l, set (
 					x => x,
-					y => h - b)));
+					y => h - b));
 
 				-- upper end:
-				set_B (l, type_vector_model (set (
+				set_B (l, set (
 					x => x,
-					y => h)));
+					y => h));
 				
 				draw_line;
 			end loop;
@@ -277,28 +277,28 @@ package body et_canvas.drawing_frame is
 				
 				-- draw the line from the left to the right:
 				-- left end:
-				set_A (l, type_vector_model (set (
+				set_A (l, set (
 					x => zero,
-					y => y)));
+					y => y));
 
 				-- right end:
-				set_B (l, type_vector_model (set (
+				set_B (l, set (
 					x => b,
-					y => y)));
+					y => y));
 
 				draw_line;
 				
 				-- RIGHT BORDER
 				-- draw the line from the left to the right:
 				-- left end:
-				set_A (l, type_vector_model (set (
+				set_A (l, set (
 					x => w - b,
-					y => y)));
+					y => y));
 
 				-- right end:
-				set_B (l, type_vector_model (set (
+				set_B (l, set (
 					x => w,
-					y => y)));
+					y => y));
 				
 				draw_line;
 			end loop;
@@ -321,14 +321,14 @@ package body et_canvas.drawing_frame is
 				-- draw index in lower border
 				draw_index (
 					content	=> to_content (to_string (i)),
-					pos		=> type_vector_model (set (x, y)));
+					pos		=> set (x, y));
 
 				-- draw index in upper border
 				draw_index (
 					content	=> to_content (to_string (i)),
-					pos		=> type_vector_model (set (
+					pos		=> set (
 								x => x,
-								y => h - y)));
+								y => h - y));
 				
 			end loop;
 
@@ -347,14 +347,14 @@ package body et_canvas.drawing_frame is
 				-- draw index in left border
 				draw_index (
 					content	=> to_content (to_string (i)),
-					pos		=> type_vector_model (set (x, y)));
+					pos		=> set (x, y));
 
 				-- draw index in right border
 				draw_index (
 					content	=> to_content (to_string (i)),
-					pos		=> type_vector_model (set (
+					pos		=> set (
 								x => w - x,
-								y => y)));
+								y => y));
 				
 			end loop;
 			

--- a/src/lib/et_canvas_board-draw_terminal.adb
+++ b/src/lib/et_canvas_board-draw_terminal.adb
@@ -391,12 +391,12 @@ is
 					when AS_PAD =>
 						-- Copy solder pad contours to stopmask without
 						-- any modifications:
-						stopmask_contours := (type_contour (pad_contours) with null record);
+						stopmask_contours := (pad_contours with null record);
 
 						
 					when EXPAND_PAD =>
 						-- Copy solder pad contour to stopmask:
-						stopmask_contours := (type_contour (pad_contours) with null record);
+						stopmask_contours := (pad_contours with null record);
 
 						-- Make a temporary polygon from the stopmask contours:
 						polygon_tmp := to_polygon (stopmask_contours, fill_tolerance, EXPAND);
@@ -679,12 +679,12 @@ is
 					when AS_PAD =>
 						-- Copy pad contours to stopmask without
 						-- any modification:
-						stopmask_contours := (type_contour (pad_contours) with null record);
+						stopmask_contours := (pad_contours with null record);
 
 						
 					when EXPAND_PAD =>
 						-- Copy pad contours to stopmask:
-						stopmask_contours := (type_contour (pad_contours) with null record);
+						stopmask_contours := (pad_contours with null record);
 
 						-- Now the stopmask must be expanded according to the DRU settings.
 
@@ -791,12 +791,12 @@ is
 					when AS_PAD =>
 						-- Copy pad contours to stencil without
 						-- any modification:
-						stencil_contours := (type_contour (pad_contours) with null record);
+						stencil_contours := (pad_contours with null record);
 
 						
 					when SHRINK_PAD =>
 						-- Copy pad contours to stencil:
-						stencil_contours := (type_contour (pad_contours) with null record);
+						stencil_contours := (pad_contours with null record);
 
 						-- Now the stencil must be shrinked according to shrink_factor:
 						

--- a/src/lib/et_canvas_schematic-draw_nets.adb
+++ b/src/lib/et_canvas_schematic-draw_nets.adb
@@ -89,7 +89,7 @@ procedure draw_nets is
 
 		procedure draw is begin
 			draw_circle (
-				circle	=> type_circle (j),
+				circle	=> j,
 				filled	=> YES,
 				width	=> zero,
 				stroke	=> DO_STROKE);

--- a/src/lib/et_canvas_schematic-draw_texts.adb
+++ b/src/lib/et_canvas_schematic-draw_texts.adb
@@ -63,7 +63,7 @@ procedure draw_texts is
 				content		=> element (cursor).content,
 				size		=> element (cursor).size,
 				font		=> text_font,
-				anchor		=> type_vector_model (element (cursor).position),
+				anchor		=> element (cursor).position,
 				origin		=> true,
 
 				-- This is documentational text. It is readable from the front or the right.

--- a/src/lib/et_cp_board_conductors.adb
+++ b/src/lib/et_cp_board_conductors.adb
@@ -782,15 +782,15 @@ package body et_cp_board_conductors is
 						width_tmp := to_distance (get_field (cmd, 8));
 
 						arc_tmp := type_arc (to_arc (
-							center		=> type_vector_model (set (
+							center		=> set (
 								x => to_distance (dd => get_field (cmd, 9)),
-								y => to_distance (dd => get_field (cmd, 10)))),
-							A	=> type_vector_model (set (
+								y => to_distance (dd => get_field (cmd, 10))),
+							A	=> set (
 								x => to_distance (dd => get_field (cmd, 11)),
-								y => to_distance (dd => get_field (cmd, 12)))),
-							B	=> type_vector_model (set (
+								y => to_distance (dd => get_field (cmd, 12))),
+							B	=> set (
 								x => to_distance (dd => get_field (cmd, 13)),
-								y => to_distance (dd => get_field (cmd, 14)))),
+								y => to_distance (dd => get_field (cmd, 14))),
 							direction	=> to_direction (get_field (cmd, 15))));
 														
 						-- draw a named track

--- a/src/lib/et_cp_board_device.adb
+++ b/src/lib/et_cp_board_device.adb
@@ -294,9 +294,9 @@ package body et_cp_board_device is
 			prefix : constant pac_device_prefix.bounded_string := 
 				to_prefix (get_field (cmd, 6));
 
-			xy : constant type_vector_model := type_vector_model (set (
+			xy : constant type_vector_model := set (
 					x => to_distance (dd => get_field (cmd, 7)),
-					y => to_distance (dd => get_field (cmd, 8))));
+					y => to_distance (dd => get_field (cmd, 8)));
 
 		begin
 			case cmd_field_count is
@@ -537,9 +537,9 @@ package body et_cp_board_device is
 					module_cursor 	=> module,
 					device_name		=> device_name,
 					coordinates		=> coordinates,
-					point			=> type_vector_model (set (
+					point			=> set (
 										x => to_distance (dd => get_field (cmd, 7)),
-										y => to_distance (dd => get_field (cmd, 8)))),
+										y => to_distance (dd => get_field (cmd, 8))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:

--- a/src/lib/et_cp_board_netchanger.adb
+++ b/src/lib/et_cp_board_netchanger.adb
@@ -235,9 +235,9 @@ package body et_cp_board_netchanger is
 						module_cursor	=> module,
 						index			=> index,
 						coordinates		=> to_coordinates (get_field (cmd, 6)),  -- relative/absolute
-						point			=> type_vector_model (set (
+						point			=> set (
 											x => to_distance (get_field (cmd, 7)),
-											y => to_distance (get_field (cmd, 8)))),						
+											y => to_distance (get_field (cmd, 8))),						
 
 						-- Depending on the origin of the command,
 						-- the design state is to be commited or not:

--- a/src/lib/et_cp_board_submodule.adb
+++ b/src/lib/et_cp_board_submodule.adb
@@ -79,9 +79,9 @@ package body et_cp_board_submodule is
 					module_name 	=> key (module),
 					instance		=> to_instance_name (get_field (cmd, 5)), -- OSC1
 					coordinates		=> to_coordinates (get_field (cmd, 6)),  -- relative/absolute
-					point			=> type_vector_model (set (
+					point			=> set (
 										x => to_distance (dd => get_field (cmd, 7)),
-										y => to_distance (dd => get_field (cmd, 8)))),
+										y => to_distance (dd => get_field (cmd, 8))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:

--- a/src/lib/et_cp_schematic_device.adb
+++ b/src/lib/et_cp_schematic_device.adb
@@ -99,11 +99,11 @@ package body et_cp_schematic_device is
 					destination		=> to_position 
 						(
 						sheet => to_sheet (get_field (cmd, 6)),
-						point => type_vector_model (set 
+						point => set 
 									(
 									x => to_distance (get_field (cmd, 7)),
 									y => to_distance (get_field (cmd, 8))
-									)),
+									),
 						rotation => to_rotation (get_field (cmd, 9))),
 					
 					variant			=> to_variant_name (""),
@@ -122,11 +122,11 @@ package body et_cp_schematic_device is
 					destination		=> to_position 
 						(
 						sheet => to_sheet (get_field (cmd, 6)),
-						point => type_vector_model (set 
+						point => set 
 									(
 									x => to_distance (get_field (cmd, 7)),
 									y => to_distance (get_field (cmd, 8))
-									)),
+									),
 						rotation		=> to_rotation (get_field (cmd, 9))
 						),
 					variant			=> to_variant_name (get_field (cmd, 10)),
@@ -291,10 +291,10 @@ package body et_cp_schematic_device is
 						
 						destination		=> to_position (
 							sheet => to_sheet (get_field (cmd, 6)),
-							point => type_vector_model (set
+							point => set
 										(
 										x => to_distance (get_field (cmd, 7)),
-										y => to_distance (get_field (cmd, 8)))),
+										y => to_distance (get_field (cmd, 8))),
 							rotation		=> to_rotation (get_field (cmd, 9))),
 							
 						-- Depending on the origin of the command,

--- a/src/lib/et_cp_schematic_netchanger.adb
+++ b/src/lib/et_cp_schematic_netchanger.adb
@@ -91,11 +91,11 @@ package body et_cp_schematic_netchanger is
 					module_cursor 	=> module,
 					place			=> to_position (
 						sheet => to_sheet (get_field (cmd, 5)),
-						point => type_vector_model (set 
+						point => set 
 									(
 									x => to_distance (get_field (cmd, 6)),
 									y => to_distance (get_field (cmd, 7))
-									)),
+									),
 						rotation		=> to_rotation (get_field (cmd, 8))),
 
 					-- Depending on the origin of the command,
@@ -150,9 +150,9 @@ package body et_cp_schematic_netchanger is
 						index			=> index,
 						coordinates		=> to_coordinates (get_field (cmd, 6)),  -- relative/absolute
 						sheet			=> to_sheet_relative (get_field (cmd, 7)),
-						point			=> type_vector_model (set (
+						point			=> set (
 											x => to_distance (get_field (cmd, 8)),
-											y => to_distance (get_field (cmd, 9)))),
+											y => to_distance (get_field (cmd, 9))),
 
 						-- Depending on the origin of the command,
 						-- the design state is to be commited or not:
@@ -207,9 +207,9 @@ package body et_cp_schematic_netchanger is
 						module_cursor 	=> module,
 						index			=> index,
 						coordinates		=> to_coordinates (get_field (cmd, 6)), -- relative/absolute
-						point			=> type_vector_model (set (
+						point			=> set (
 											x => to_distance (get_field (cmd, 7)),
-											y => to_distance (get_field (cmd, 8)))),
+											y => to_distance (get_field (cmd, 8))),
 
 						-- Depending on the origin of the command,
 						-- the design state is to be commited or not:

--- a/src/lib/et_cp_schematic_nets.adb
+++ b/src/lib/et_cp_schematic_nets.adb
@@ -305,9 +305,9 @@ package body et_cp_schematic_nets is
 				place_net_connector (
 					module_cursor	=> module,
 					position		=> to_position (
-						point => type_vector_model (set (
+						point => set (
 							x => to_distance (get_field (cmd, 6)),
-							y => to_distance (get_field (cmd, 7)))),
+							y => to_distance (get_field (cmd, 7))),
 						sheet => to_sheet (get_field (cmd, 5))), -- sheet number
 	
 					-- A connector requires specification of signal direction:
@@ -384,9 +384,9 @@ package body et_cp_schematic_nets is
 				place_net_label (
 					module_cursor	=> module,
 					position		=> to_position (
-						point => type_vector_model (set (
+						point => set (
 							x => to_distance (get_field (cmd, 6)),
-							y => to_distance (get_field (cmd, 7)))),
+							y => to_distance (get_field (cmd, 7))),
 						sheet => to_sheet (get_field (cmd, 5))), -- sheet number
 
 					-- Depending on the origin of the command,
@@ -433,9 +433,9 @@ package body et_cp_schematic_nets is
 					module_cursor	=> module,
 
 					position		=> to_position (
-						point => type_vector_model (set (
+						point => set (
 							x => to_distance (get_field (cmd, 6)),
-							y => to_distance (get_field (cmd, 7)))),
+							y => to_distance (get_field (cmd, 7))),
 						sheet => to_sheet (get_field (cmd, 5))), -- sheet number
 
 					-- Depending on the origin of the command,

--- a/src/lib/et_cp_schematic_submodule.adb
+++ b/src/lib/et_cp_schematic_submodule.adb
@@ -98,11 +98,11 @@ package body et_cp_schematic_submodule is
 					position		=> to_position 
 						(
 						sheet => to_sheet (get_field (cmd, 7)),
-						point => type_vector_model (set 
+						point => set 
 									(
 									x => to_distance (get_field (cmd, 8)),
 									y => to_distance (get_field (cmd, 9))
-									))
+									)
 						),
 					size => (
 						x => to_distance (get_field (cmd, 10)),
@@ -155,9 +155,9 @@ package body et_cp_schematic_submodule is
 					instance		=> to_instance_name (get_field (cmd, 5)),
 					coordinates		=> to_coordinates (get_field (cmd, 6)),  -- relative/absolute
 					sheet			=> to_sheet_relative (get_field (cmd, 7)),
-					point			=> type_vector_model (set (
+					point			=> set (
 								x => to_distance (get_field (cmd, 8)),
-								y => to_distance (get_field (cmd, 9)))),
+								y => to_distance (get_field (cmd, 9))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:
@@ -202,9 +202,9 @@ package body et_cp_schematic_submodule is
 					module_name 	=> key (module),
 					instance		=> to_instance_name (get_field (cmd, 5)),
 					coordinates		=> to_coordinates (get_field (cmd, 6)),  -- relative/absolute
-					point			=> type_vector_model (set (
+					point			=> set (
 								x => to_distance (get_field (cmd, 7)),
-								y => to_distance (get_field (cmd, 8)))),
+								y => to_distance (get_field (cmd, 8))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:
@@ -253,11 +253,11 @@ package body et_cp_schematic_submodule is
 					destination		=> to_position 
 						(
 						sheet => to_sheet (get_field (cmd, 7)),
-						point => type_vector_model (set
+						point => set
 									(
 									x => to_distance (get_field (cmd, 8)),
 									y => to_distance (get_field (cmd, 9))
-									))
+									)
 						),
 
 					-- Depending on the origin of the command,
@@ -601,11 +601,11 @@ package body et_cp_schematic_submodule is
 					module_name 	=> key (module),
 					instance		=> to_instance_name (get_field (cmd, 5)),
 					port_name		=> to_net_name (get_field (cmd, 6)),
-					position		=> type_vector_model (set 
+					position		=> set 
 								(
 								x => to_distance (get_field (cmd, 7)),
 								y => to_distance (get_field (cmd, 8))
-								)),
+								),
 					direction		=> to_port_name (get_field (cmd, 9)),
 
 					-- Depending on the origin of the command,
@@ -652,9 +652,9 @@ package body et_cp_schematic_submodule is
 					instance		=> to_instance_name (get_field (cmd, 5)),
 					port_name		=> to_net_name (get_field (cmd, 6)),
 					coordinates		=> to_coordinates (get_field (cmd, 7)),  -- relative/absolute
-					point			=> type_vector_model (set (
+					point			=> set (
 								x => to_distance (get_field (cmd, 8)),
-								y => to_distance (get_field (cmd, 9)))),
+								y => to_distance (get_field (cmd, 9))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:
@@ -745,9 +745,9 @@ package body et_cp_schematic_submodule is
 					instance		=> to_instance_name (get_field (cmd, 5)),
 					port_name		=> to_net_name (get_field (cmd, 6)),
 					coordinates		=> to_coordinates (get_field (cmd, 7)),  -- relative/absolute
-					point			=> type_vector_model (set (
+					point			=> set (
 								x => to_distance (get_field (cmd, 8)),
-								y => to_distance (get_field (cmd, 9)))),
+								y => to_distance (get_field (cmd, 9))),
 
 					-- Depending on the origin of the command,
 					-- the design state is to be commited or not:

--- a/src/lib/et_cp_schematic_unit.adb
+++ b/src/lib/et_cp_schematic_unit.adb
@@ -620,9 +620,9 @@ package body et_cp_schematic_unit is
 						device_name		=> device_name,
 						unit_name		=> unit_name,
 						coordinates		=> to_coordinates (get_field (cmd, 7)), -- relative/absolute
-						destination		=> type_vector_model (set (
+						destination		=> set (
 											x => to_distance (get_field (cmd, 8)),
-											y => to_distance (get_field (cmd, 9)))),
+											y => to_distance (get_field (cmd, 9))),
 
 						-- Depending on the origin of the command,
 						-- the design state is to be commited or not:

--- a/src/lib/et_drawing_frame_rw.adb
+++ b/src/lib/et_drawing_frame_rw.adb
@@ -273,7 +273,7 @@ package body et_drawing_frame_rw is
 			section_mark (section_placeholders, HEADER);
 			write_placeholders_common (block.placeholders_common);
 
-			ps := type_title_block_schematic (block).placeholders_additional;
+			ps := block.placeholders_additional;
 			write_placeholders_schematic (ps);
 				
 			section_mark (section_placeholders, FOOTER);
@@ -591,13 +591,13 @@ package body et_drawing_frame_rw is
 			write_placeholders_common (block.placeholders_common);
 
 
-			pp := type_title_block_pcb (block).placeholders_additional;
+			pp := block.placeholders_additional;
 			write_placeholders_pcb (pp);
 
 			section_mark (section_placeholders, FOOTER);
 
 			-- CAM MARKERS
-			write_cam_markers (type_title_block_pcb (block).cam_markers);
+			write_cam_markers (block.cam_markers);
 		end write_title_block;
 
 		

--- a/src/lib/et_fill_zones.adb
+++ b/src/lib/et_fill_zones.adb
@@ -174,7 +174,7 @@ package body et_fill_zones is
 
 				-- Round up the number of stripes to the next natural number (like 7)
 				stripe_count_natural := natural (type_float_positive'ceiling (
-						type_float_positive (stripe_count_rational)));
+						stripe_count_rational));
 				
 
 				stripe_spacing := height / type_float_positive (stripe_count_natural);

--- a/src/lib/et_geometry_1-et_polygons-union.adb
+++ b/src/lib/et_geometry_1-et_polygons-union.adb
@@ -256,7 +256,7 @@ package body et_geometry_1.et_polygons.union is
 				
 					-- Make a polygon from the primary collection of vertices
 					-- and append it to the candidate list of polygons:
-					candidate_polygons.append (type_polygon (to_polygon (vertices_tmp_1)));
+					candidate_polygons.append (to_polygon (vertices_tmp_1));
 
 				end query_outside_vertex;
 				
@@ -312,7 +312,7 @@ package body et_geometry_1.et_polygons.union is
 					-- then the resulting polygon is complete:
 					if element (vertice_A_cursor).position = start_point then
 						-- Make a polygon from the primary collection of vertices:
-						result_polygon := type_polygon (to_polygon (vertices_tmp_1));
+						result_polygon := to_polygon (vertices_tmp_1);
 												
 						exit WALK_METHOD_2; -- Terminate this loop:
 					end if;
@@ -428,7 +428,7 @@ package body et_geometry_1.et_polygons.union is
 				when CONGRUENT =>
 					put_line ("CONGRUENT");
 					-- The result is just polygon A:
-					result_polygon := type_polygon (polygon_A);
+					result_polygon := polygon_A;
 					
 				when A_DOES_NOT_OVERLAP_B => 
 					-- No union possible.
@@ -437,12 +437,12 @@ package body et_geometry_1.et_polygons.union is
 				when A_INSIDE_B => 
 					-- Polygon A is completely inside B. So the result
 					-- is just polygon B:
-					result_polygon := type_polygon (polygon_B);
+					result_polygon := polygon_B;
 
 				when B_INSIDE_A =>
 					-- Polygon B is completely inside A. So the result
 					-- is just polygon A:
-					result_polygon := type_polygon (polygon_A);
+					result_polygon := polygon_A;
 
 				when A_OVERLAPS_B => 
 					-- Do the actual union work:

--- a/src/lib/et_geometry_1-et_polygons.adb
+++ b/src/lib/et_geometry_1-et_polygons.adb
@@ -989,15 +989,15 @@ package body et_geometry_1.et_polygons is
 		procedure query_edge (c : in pac_edges.cursor) is
 			x1, x2, y1, y2 : type_float;
 		begin
-			x1 := type_float (get_x (element (c).A));
-			y1 := type_float (get_y (element (c).A));
+			x1 := get_x (element (c).A);
+			y1 := get_y (element (c).A);
 
 			if c /= polygon.edges.last then
-				x2 := type_float (get_x (element (next (c)).A));
-				y2 := type_float (get_y (element (next (c)).A));
+				x2 := get_x (element (next (c)).A);
+				y2 := get_y (element (next (c)).A);
 			else
-				x2 := type_float (get_x (element (polygon.edges.first).A));
-				y2 := type_float (get_y (element (polygon.edges.first).A));
+				x2 := get_x (element (polygon.edges.first).A);
+				y2 := get_y (element (polygon.edges.first).A);
 			end if;
 
 			-- Sum over the edges, (x2 − x1)(y2 + y1).

--- a/src/lib/et_geometry_1.adb
+++ b/src/lib/et_geometry_1.adb
@@ -1413,8 +1413,8 @@ package body et_geometry_1 is
 	is 
 		result : type_line_vector := lv;
 	begin
-		result.v_start.x := result.v_start.x + type_float (offset.x);
-		result.v_start.y := result.v_start.y + type_float (offset.y);
+		result.v_start.x := result.v_start.x + offset.x;
+		result.v_start.y := result.v_start.y + offset.y;
 
 		return result;
 	end move_by;
@@ -1431,8 +1431,8 @@ package body et_geometry_1 is
 
 		--a := to_rotation (arctan (
 		a := arctan (
-				y		=> type_float (line.v_direction.y), 
-				x		=> type_float (line.v_direction.x), 
+				y		=> line.v_direction.y, 
+				x		=> line.v_direction.x, 
 				cycle	=> units_per_cycle);
 
 		-- dz ignored. we are in a 2D world
@@ -3318,11 +3318,11 @@ package body et_geometry_1 is
 			v_end := add (line_moved.v_start, line_moved.v_direction);
 			
 			-- compute start and end point of line:
-			x1 := type_float (get_x (line_moved.v_start));
-			y1 := type_float (get_y (line_moved.v_start));
+			x1 := get_x (line_moved.v_start);
+			y1 := get_y (line_moved.v_start);
 			
-			x2 := type_float (get_x (v_end));
-			y2 := type_float (get_y (v_end));
+			x2 := get_x (v_end);
+			y2 := get_y (v_end);
 			
 			dx := x2 - x1; -- the delta in x
 			dy := y2 - y1; -- the delta in y

--- a/src/lib/et_kicad_packages.adb
+++ b/src/lib/et_kicad_packages.adb
@@ -206,11 +206,11 @@ package body et_kicad_packages is
 
 	begin -- to_pad_shape_rectangle
 		-- set supportive cornert points
-		p11 := type_vector_model (set (x => xn, y => yp));
-		p12 := type_vector_model (set (x => xn, y => yn));
+		p11 := set (x => xn, y => yp);
+		p12 := set (x => xn, y => yn);
 
-		p21 := type_vector_model (set (x => xp, y => yp));
-		p22 := type_vector_model (set (x => xp, y => yn));
+		p21 := set (x => xp, y => yp);
+		p22 := set (x => xp, y => yn);
 
 		-- rotate supportive points
 		rotate_by (p11, angle);
@@ -291,18 +291,18 @@ package body et_kicad_packages is
 
 		-- set supportive points
 		-- upper line
-		p11 := type_vector_model (set (x => x2n, y => y1p));
-		p12 := type_vector_model (set (x => x2p, y => y1p));
+		p11 := set (x => x2n, y => y1p);
+		p12 := set (x => x2p, y => y1p);
 
 		-- lower line
-		p21 := type_vector_model (set (x => x2n, y => y1n));
-		p22 := type_vector_model (set (x => x2p, y => y1n));
+		p21 := set (x => x2n, y => y1n);
+		p22 := set (x => x2p, y => y1n);
 
 		-- left arc
-		p41 := type_vector_model (set (x => x2n,  y => zero));
+		p41 := set (x => x2n,  y => zero);
 
 		-- right arc
-		p42 := type_vector_model (set (x => x2p,  y => zero));
+		p42 := set (x => x2p,  y => zero);
 		
 		-- rotate supportive points 
 		rotate_by (p11, angle);
@@ -384,11 +384,11 @@ package body et_kicad_packages is
 
 	begin -- to_pad_milling_contour
 		-- set supportive cornert points
-		p11 := type_vector_model (set (x => xn, y => yp)); -- top left
-		p12 := type_vector_model (set (x => xn, y => yn)); -- bottom left
+		p11 := set (x => xn, y => yp); -- top left
+		p12 := set (x => xn, y => yn); -- bottom left
 
-		p21 := type_vector_model (set (x => xp, y => yp)); -- top right
-		p22 := type_vector_model (set (x => xp, y => yn)); -- bottom right
+		p21 := set (x => xp, y => yp); -- top right
+		p22 := set (x => xp, y => yn); -- bottom right
 
 		-- rotate supportive points
 		rotate_by (p11, angle);

--- a/src/lib/et_kicad_to_native.adb
+++ b/src/lib/et_kicad_to_native.adb
@@ -2429,8 +2429,8 @@ package body et_kicad_to_native is
 			log (text => "width" & to_string (width), level => log_threshold + 2);
 			
 			if width < zero then
-				rectangle.corner_A := type_vector_model (invert (rectangle.corner_A, MIRROR_ALONG_X_AXIS));
-				rectangle.corner_B := type_vector_model (invert (rectangle.corner_B, MIRROR_ALONG_X_AXIS));
+				rectangle.corner_A := invert (rectangle.corner_A, MIRROR_ALONG_X_AXIS);
+				rectangle.corner_B := invert (rectangle.corner_B, MIRROR_ALONG_X_AXIS);
 				width := - width;
 			end if;
 			
@@ -2439,8 +2439,8 @@ package body et_kicad_to_native is
 			log (text => "height" & to_string (height), level => log_threshold + 2);
 			
 			if height < zero then
-				rectangle.corner_A := type_vector_model (invert (rectangle.corner_A, MIRROR_ALONG_Y_AXIS));
-				rectangle.corner_B := type_vector_model (invert (rectangle.corner_B, MIRROR_ALONG_Y_AXIS));
+				rectangle.corner_A := invert (rectangle.corner_A, MIRROR_ALONG_Y_AXIS);
+				rectangle.corner_B := invert (rectangle.corner_B, MIRROR_ALONG_Y_AXIS);
 				height := - height;
 			end if;
 
@@ -2453,16 +2453,16 @@ package body et_kicad_to_native is
 			-- corner_B is the upper right corner of the rectangle
 
 			-- corner_C is the lower right corner:
-			corner_C := type_vector_model (set (
+			corner_C := set (
 				x => get_x (rectangle.corner_A) + width,
 				y => get_y (rectangle.corner_A)
-				));
+				);
 
 			-- corner_D is the upper left corner:
-			corner_D := type_vector_model (set (
+			corner_D := set (
 				x => get_x (rectangle.corner_A),
 				y => get_y (rectangle.corner_A) + height
-				));
+				);
 			
 			-- lower horizontal line
 			set_A (line, rectangle.corner_A);

--- a/src/lib/et_net_strands.adb
+++ b/src/lib/et_net_strands.adb
@@ -271,9 +271,9 @@ package body et_net_strands is
 		--log (text => "set strand position");
 		
 		-- init point_1 as the farest possible point from drawing origin
-		point_1 := type_vector_model (set (
+		point_1 := set (
 					x => type_position_axis'last,
-					y => type_position_axis'last));
+					y => type_position_axis'last);
 
 		-- loop through segments and keep the nearest point to origin
 		iterate (strand.segments, query_strand'access);

--- a/src/lib/et_package_write_terminals.adb
+++ b/src/lib/et_package_write_terminals.adb
@@ -194,7 +194,7 @@ package body et_package_write_terminals is
 			millings : in type_contour) 
 		is begin
 			section_mark (section_pad_millings, HEADER);
-			write_polygon_segments (type_contour (millings));
+			write_polygon_segments (millings);
 			section_mark (section_pad_millings, FOOTER);
 		end write_plated_millings;
 
@@ -268,12 +268,12 @@ package body et_package_write_terminals is
 					section_mark (section_pad_contours_tht, HEADER);
 					
 					section_mark (section_top, HEADER);
-					write_polygon_segments (type_contour (element (terminal_cursor).pad_shape_tht.top));
+					write_polygon_segments (element (terminal_cursor).pad_shape_tht.top);
 					section_mark (section_top, FOOTER);
 
 					-- pad contour bottom
 					section_mark (section_bottom, HEADER);
-					write_polygon_segments (type_contour (element (terminal_cursor).pad_shape_tht.bottom));
+					write_polygon_segments (element (terminal_cursor).pad_shape_tht.bottom);
 					section_mark (section_bottom, FOOTER);
 					
 					section_mark (section_pad_contours_tht, FOOTER);
@@ -299,7 +299,7 @@ package body et_package_write_terminals is
 				when SMT =>
 					-- pad contour
 					section_mark (section_pad_contours_smt, HEADER);
-					write_polygon_segments (type_contour (element (terminal_cursor).pad_shape_smt));
+					write_polygon_segments (element (terminal_cursor).pad_shape_smt);
 					section_mark (section_pad_contours_smt, FOOTER);
 					
 					write (keyword => keyword_face, 

--- a/src/lib/et_schematic_ops_units.adb
+++ b/src/lib/et_schematic_ops_units.adb
@@ -2491,7 +2491,7 @@ package body et_schematic_ops_units is
 							-- build the new position while preserving rotation:
 							unit.position := to_position (
 								point		=> destination, 
-								sheet		=> type_sheet (sheet),
+								sheet		=> sheet,
 								rotation	=> get_rotation (unit.position));
 
 						when RELATIVE =>

--- a/src/lib/et_string_processing.adb
+++ b/src/lib/et_string_processing.adb
@@ -825,7 +825,7 @@ package body et_string_processing is
 		line : in type_fields_of_line) 
 		return positive 
 	is begin
-		return positive (line.number);
+		return line.number;
 	end get_line_number;
 
 


### PR DESCRIPTION
I do not know if you accept this PR (I do not like to delete some of your valuable work).
Perhaps you meant the conversion to be explanatory and could be replaced with qualification like `type_other'()`?