### PR TITLE
Remove redundant others choice from case constructs

### DIFF
--- a/src/lib/et_canvas-cmd.adb
+++ b/src/lib/et_canvas-cmd.adb
@@ -351,7 +351,6 @@ package body et_canvas.cmd is
 				when NOUN_SCALE =>
 					set_scale;				
 					
-				when others => invalid_noun (to_string (noun));
 			end case;
 		end evaluate_on_verb_set;
 

--- a/src/lib/et_canvas.adb
+++ b/src/lib/et_canvas.adb
@@ -465,7 +465,6 @@ package body et_canvas is
 				decrease_zoom_factor;
 				-- put_line (" zoom out");
 				
-			when others => null;
 		end case;
 
 		update_zoom_display;

--- a/src/lib/et_canvas_board_lines.adb
+++ b/src/lib/et_canvas_board_lines.adb
@@ -856,8 +856,6 @@ package body et_canvas_board_lines is
 			when LAYER_CAT_STOPMASK =>
 				add_to_stopmask;
 
-			when others =>
-				null; -- CS
 		end case;
 
 		-- Commit the new state of the design:

--- a/src/lib/et_colors-board.adb
+++ b/src/lib/et_colors-board.adb
@@ -124,7 +124,6 @@ package body et_colors.board is
 			when STRIPED_90		=> make_gradient_90;
 			when STRIPED_135	=> make_gradient_135;
 				
-			when others => null;
 		end case;
 
 		case style is

--- a/src/lib/et_cp_board_assy_doc.adb
+++ b/src/lib/et_cp_board_assy_doc.adb
@@ -192,7 +192,6 @@ package body et_cp_board_assy_doc is
 							command_incomplete (cmd);
 					end case;
 							
-				when others => null;
 			end case;
 		end draw_shape;
 

--- a/src/lib/et_cp_board_restrict.adb
+++ b/src/lib/et_cp_board_restrict.adb
@@ -240,7 +240,6 @@ package body et_cp_board_restrict is
 						when others => command_incomplete (cmd);
 					end case;
 							
-				when others => null;
 			end case;
 		end if;
 

--- a/src/lib/et_cp_board_silkscreen.adb
+++ b/src/lib/et_cp_board_silkscreen.adb
@@ -196,7 +196,6 @@ package body et_cp_board_silkscreen is
 							command_incomplete (cmd);
 					end case;
 							
-				when others => null;
 			end case;
 		end draw_shape;
 

--- a/src/lib/et_cp_board_stencil.adb
+++ b/src/lib/et_cp_board_stencil.adb
@@ -193,7 +193,6 @@ package body et_cp_board_stencil is
 							command_incomplete (cmd);
 					end case;
 							
-				when others => null;
 			end case;
 		end draw_shape;
 

--- a/src/lib/et_cp_board_stopmask.adb
+++ b/src/lib/et_cp_board_stopmask.adb
@@ -194,7 +194,6 @@ package body et_cp_board_stopmask is
 							command_incomplete (cmd);
 					end case;
 							
-				when others => null;
 			end case;
 		end draw_shape;
 

--- a/src/lib/et_cp_project.adb
+++ b/src/lib/et_cp_project.adb
@@ -142,7 +142,6 @@ package body et_cp_project is
 								when others => command_incomplete;
 							end case;							
 							
-						when others => invalid_noun (to_string (noun));
 					end case;
 
 					
@@ -159,7 +158,6 @@ package body et_cp_project is
 									
 								when others => command_incomplete;
 							end case;							
-						when others => invalid_noun (to_string (noun));
 					end case;
 
 					
@@ -177,7 +175,6 @@ package body et_cp_project is
 								when others => command_incomplete;
 							end case;			
 							
-						when others => invalid_noun (to_string (noun));
 					end case;
 
 					
@@ -195,7 +192,6 @@ package body et_cp_project is
 								when others => command_incomplete;
 							end case;			
 							
-						when others => invalid_noun (to_string (noun));
 					end case;
 					
 			end case;

--- a/src/lib/et_device_read_unit.adb
+++ b/src/lib/et_device_read_unit.adb
@@ -102,9 +102,6 @@ package body et_device_read_unit is
 						appearance	=> APPEARANCE_PCB,
 						others		=> <>);
 
-				when others => 
-					raise constraint_error; -- CS
-
 			end case;
 			
 		elsif kw = keyword_position then -- position x 0.00 y 0.00

--- a/src/lib/et_fonts.adb
+++ b/src/lib/et_fonts.adb
@@ -73,8 +73,6 @@ package body et_fonts is
 			when FAMILY_MONOSPACE =>
 				result.family := to_family ("monospace");
 
-			when others =>
-				null; -- CS
 		end case;
 
 
@@ -85,8 +83,6 @@ package body et_fonts is
 			when SLANT_ITALIC =>
 				result.slant := CAIRO_FONT_SLANT_ITALIC;
 				
-			when others =>
-				null; -- CS
 		end case;
 
 
@@ -94,7 +90,6 @@ package body et_fonts is
 			when WEIGHT_NORMAL =>
 				result.weight := CAIRO_FONT_WEIGHT_NORMAL;
 
-			when others => null;
 		end case;
 
 		return result;

--- a/src/lib/et_kicad-pcb.adb
+++ b/src/lib/et_kicad-pcb.adb
@@ -2481,7 +2481,6 @@ package body et_kicad.pcb is
 								when 2 => board.general.area_y1 := to_distance (to_string (arg));								
 								when 3 => board.general.area_x2 := to_distance (to_string (arg));
 								when 4 => board.general.area_y2 := to_distance (to_string (arg));
-								when others => too_many_arguments;
 							end case;
 
 						when SEC_THICKNESS =>

--- a/src/lib/et_kicad-schematic.adb
+++ b/src/lib/et_kicad-schematic.adb
@@ -2716,7 +2716,6 @@ package body et_kicad.schematic is
 											when 0 => null;
 											when 1 =>
 												lib_name := type_library_name.to_bounded_string (to_string (arg));
-											when others => too_many_arguments;
 										end case;
 
 									when SEC_TYPE =>
@@ -2724,7 +2723,6 @@ package body et_kicad.schematic is
 											when 0 => null;
 											when 1 =>
 												lib_type := type_lib_type'value (to_string (arg));
-											when others => too_many_arguments;
 										end case;
 
 									when SEC_URI =>
@@ -2732,7 +2730,6 @@ package body et_kicad.schematic is
 											when 0 => null;
 											when 1 =>
 												lib_uri := to_file_name (to_string (arg));
-											when others => too_many_arguments;
 										end case;
 
 									when SEC_OPTIONS =>
@@ -2741,7 +2738,6 @@ package body et_kicad.schematic is
 											when 1 =>
 												-- CS lib_options := to_bounded_string (to_string (arg));
 												null;
-											when others => too_many_arguments;
 										end case;
 
 									when SEC_DESCR =>
@@ -2750,7 +2746,6 @@ package body et_kicad.schematic is
 											when 1 =>
 												-- CS lib_description := to_bounded_string (to_string (arg));
 												null;
-											when others => too_many_arguments;
 										end case;
 
 									when others => invalid_section;

--- a/src/lib/et_kicad_packages.adb
+++ b/src/lib/et_kicad_packages.adb
@@ -1170,7 +1170,6 @@ package body et_kicad_packages is
 										null;
 									end if;
 									
-								when others => too_many_arguments;
 							end case;
 
 						when others => invalid_section;
@@ -1525,7 +1524,6 @@ package body et_kicad_packages is
 									set (axis => AXIS_Y, point => terminal_position.place, value => to_distance (to_string (arg)));
 								when 3 => 
 									set_rotation (terminal_position, to_rotation (to_string (arg)));
-								when others => too_many_arguments;
 							end case;
 
 						when SEC_FP_TEXT =>
@@ -1540,7 +1538,6 @@ package body et_kicad_packages is
 								when 3 => 
 									--text.angle := to_angle (to_string (arg));
 									set_rotation (text.position, to_rotation (to_string (arg)));
-								when others => too_many_arguments;
 							end case;
 							
 						when others => invalid_section;
@@ -1571,7 +1568,6 @@ package body et_kicad_packages is
 										when OVAL => terminal_milling_size_y := to_distance (to_string (arg)); -- 5.5
 									end case;
 									
-								when others => too_many_arguments;
 							end case;
 
 						when others => invalid_section;
@@ -1663,7 +1659,6 @@ package body et_kicad_packages is
 										when SMT => terminal_pad_shape_smt := to_pad_shape_smt (to_string (arg));
 										when THT => terminal_pad_shape_tht := to_pad_shape_tht (to_string (arg));
 									end case;
-								when others => too_many_arguments;
 							end case;
 
 						when others => invalid_section;

--- a/src/lib/et_module_read_device_electrical.adb
+++ b/src/lib/et_module_read_device_electrical.adb
@@ -785,9 +785,6 @@ package body et_module_read_device_electrical is
 					meaning		=> PURPOSE,
 					position	=> unit_placeholder_position);
 
-			when others =>
-				log (SEVERITY_ERROR, "meaning of placeholder not supported !", console => true);
-				raise constraint_error;
 		end case;
 
 		-- clean up for next placeholder

--- a/src/lib/et_symbol_read_text.adb
+++ b/src/lib/et_symbol_read_text.adb
@@ -213,9 +213,6 @@ package body et_symbol_read_text is
 					meaning		=> symbol_placeholder_meaning);
 
 			-- Default meaning causes an error:
-			when others => 
-				log (SEVERITY_ERROR, "meaning of placeholder not specified !");
-				raise constraint_error;
 		end case;
 
 		


### PR DESCRIPTION
This PR deletes some code, calls to `invalid_noun`, `log`, and `too_many_arguments`, but it should be safe as they should never be called anyway.

Deleting redundant others choice will lead to build error if a new possibility is added to an enumeration (advantage).