### PR TITLE
Add unused_ to variables not referenced

### DIFF
--- a/src/et/et.adb
+++ b/src/et/et.adb
@@ -129,7 +129,7 @@ procedure et is
 
 	frame_name_create		: et_drawing_frame.pac_template_name.bounded_string; -- the frame to be created like lib/frames/A3_landscape.frs
 	frame_name_open			: et_drawing_frame.pac_template_name.bounded_string;
-	frame_name_save_as		: et_drawing_frame.pac_template_name.bounded_string;
+	unused_frame_name_save_as	: et_drawing_frame.pac_template_name.bounded_string;
 	frame_domain			: et_drawing_frame.type_domain := et_drawing_frame.DOMAIN_SCHEMATIC;
 	
 	script_name				: pac_script_name.bounded_string;
@@ -304,7 +304,7 @@ procedure et is
 						
 					elsif full_switch = switch_frame_schematic_save_as then
 						log (text => arg & full_switch & space & parameter);
-						frame_name_save_as := et_drawing_frame.to_template_name (parameter);
+						unused_frame_name_save_as := et_drawing_frame.to_template_name (parameter);
 
 
 					-- frame pcb
@@ -320,7 +320,7 @@ procedure et is
 						
 					elsif full_switch = switch_frame_pcb_save_as then
 						log (text => arg & full_switch & space & parameter);
-						frame_name_save_as := et_drawing_frame.to_template_name (parameter);
+						unused_frame_name_save_as := et_drawing_frame.to_template_name (parameter);
 						
 					-- script
 					elsif full_switch = switch_execute_script then

--- a/src/lib/et_board_ops_fill_zones.adb
+++ b/src/lib/et_board_ops_fill_zones.adb
@@ -1092,11 +1092,11 @@ package body et_board_ops_fill_zones is
 		-- If a parent net was given (via argument parent_net) then
 		-- this will hold the actual net name like "GND".
 		-- Otherwise it will be left empty:
-		parent_net_name : pac_net_name.bounded_string;
+		unused_parent_net_name : pac_net_name.bounded_string;
 
 		procedure set_parent_net_name is begin
 			if parent_net /= pac_nets.no_element then
-				parent_net_name := key (parent_net);
+				unused_parent_net_name := key (parent_net);
 			end if;
 		end set_parent_net_name;
 
@@ -1622,9 +1622,9 @@ package body et_board_ops_fill_zones is
 		relief_properties	: type_relief_properties;
 		terminal_reliefes	: pac_reliefes.list;
 		terminal_connection	: type_pad_connection := pad_connection_default;
-		terminal_technology	: type_pad_technology := pad_technology_default;
+		unused_terminal_technology	: type_pad_technology := pad_technology_default;
 		
-		native_tracks_embedded : type_native_tracks_embedded := false;
+		unused_native_tracks_embedded : type_native_tracks_embedded := false;
 		-- CS currently not used
 
 		
@@ -1668,10 +1668,10 @@ package body et_board_ops_fill_zones is
 					-- load temporarily variables of zone properties:
 					relief_properties := zone.relief_properties;
 					terminal_connection	:= zone.connection;
-					native_tracks_embedded := zone.native_tracks_embedded;
+					unused_native_tracks_embedded := zone.native_tracks_embedded;
 
 					if zone.connection = SOLID then
-						terminal_technology	:= zone.technology;
+						unused_terminal_technology	:= zone.technology;
 					end if;
 
 
@@ -1747,10 +1747,10 @@ package body et_board_ops_fill_zones is
 					-- load temporarily variables of zone properties:
 					relief_properties := zone.relief_properties;
 					terminal_connection	:= zone.connection;
-					native_tracks_embedded := zone.native_tracks_embedded;
+					unused_native_tracks_embedded := zone.native_tracks_embedded;
 
 					if zone.connection = SOLID then
-						terminal_technology	:= zone.technology;
+						unused_terminal_technology	:= zone.technology;
 					end if;
 					
 					

--- a/src/lib/et_board_ops_frame.adb
+++ b/src/lib/et_board_ops_frame.adb
@@ -67,14 +67,14 @@ package body et_board_ops_frame is
 			module		: in out type_generic_module) 
 		is 
 			pragma unreferenced (module_name);
-			p1 : et_drawing_frame.type_position;
+			unused_p1 : et_drawing_frame.type_position;
 		begin
 			case coordinates is
 				when ABSOLUTE =>
 					set_position (module.board.frame.frame, point);
 
 				when RELATIVE =>
-					p1 := get_position (module.board.frame.frame);
+					unused_p1 := get_position (module.board.frame.frame);
 					-- CS
 					-- move_by (module.board.frame.position, to_distance_relative (point));
 			end case;

--- a/src/lib/et_canvas.adb
+++ b/src/lib/et_canvas.adb
@@ -984,7 +984,7 @@ package body et_canvas is
 		v_start, v_length, v_end : type_logical_pixels;
 
 		-- The four corners of the visible area:
-		BL, BR, TL, TR : type_vector_model;
+		BL, unused_BR, TL, TR : type_vector_model;
 	begin
 		-- Inquire the allocation of the scrolled window
 		-- inside the main window:
@@ -1022,7 +1022,7 @@ package body et_canvas is
 		-- Compute the corners of the visible area.
 		-- The corners are real model coordinates:
 		BL := canvas_to_real ((h_start, v_end),   S);
-		BR := canvas_to_real ((h_end, v_end),     S);
+		unused_BR := canvas_to_real ((h_end, v_end),     S);
 		TL := canvas_to_real ((h_start, v_start), S);
 		TR := canvas_to_real ((h_end, v_start),   S);
 

--- a/src/lib/et_canvas_board.adb
+++ b/src/lib/et_canvas_board.adb
@@ -1143,13 +1143,13 @@ package body et_canvas_board is
 		pragma unreferenced (canvas);
 		event_handled : constant boolean := true;
 
-		mouse_event : type_mouse_event;
+		unused_mouse_event : type_mouse_event;
 		
 		debug : boolean := false;
 	begin
 		-- put_line ("cb_canvas_button_released (board)");
 		
-		mouse_event := get_mouse_button_released_event (event);
+		unused_mouse_event := get_mouse_button_released_event (event);
 
 		 -- CS button_released (mouse_event);
 		

--- a/src/lib/et_canvas_schematic.adb
+++ b/src/lib/et_canvas_schematic.adb
@@ -873,7 +873,7 @@ package body et_canvas_schematic is
 		pragma unreferenced (canvas);
 		event_handled : constant boolean := true;
 
-		mouse_event : type_mouse_event;
+		unused_mouse_event : type_mouse_event;
 		
 		debug : boolean := false;
 
@@ -910,7 +910,7 @@ package body et_canvas_schematic is
 	begin
 		-- put_line ("cb_canvas_button_released (schematic)");
 		
-		mouse_event := get_mouse_button_released_event (event);
+		unused_mouse_event := get_mouse_button_released_event (event);
 
 		-- CS button_released (mouse_event);
 

--- a/src/lib/et_canvas_schematic_units.adb
+++ b/src/lib/et_canvas_schematic_units.adb
@@ -1334,13 +1334,13 @@ package body et_canvas_schematic_units is
 
 		
 		procedure do_it is
-			device	: type_device_name; -- IC1
+			unused_device	: type_device_name; -- IC1
 
 			use pac_package_variant_name;
 			variant	: pac_package_variant_name.bounded_string;
 		begin
 			-- Get the name of the selected device:
-			device := get_device_name (object.unit.device_cursor);
+			unused_device := get_device_name (object.unit.device_cursor);
 
 			-- Get the old variant of the selected device:
 			variant := get_package_variant (object.unit.device_cursor);
@@ -2318,7 +2318,7 @@ package body et_canvas_schematic_units is
 		device_model : pac_device_model_file.bounded_string;
 		device_cursor_lib : pac_device_models.cursor;
 
-		units_total : type_unit_count;
+		unused_units_total : type_unit_count;
 
 		use pac_unit_names;
 		unit_names : pac_unit_names.list;
@@ -2452,7 +2452,7 @@ package body et_canvas_schematic_units is
 				-- CS use device_cursor_lib := get_device_model (object.unit.device_cursor);
 				-- instead of the statements above.
 
-				units_total := get_unit_count (device_cursor_lib);
+				unused_units_total := get_unit_count (device_cursor_lib);
 
 				-- collect the names of all units of the selected device:
 				-- put_line ("get all units");

--- a/src/lib/et_cp_board_keepout.adb
+++ b/src/lib/et_cp_board_keepout.adb
@@ -138,9 +138,9 @@ package body et_cp_board_keepout is
 			-- Build the basic contour from zone:
 			c : constant type_contour := type_contour (to_contour (arguments));
 
-			face : type_face;
+			unused_face : type_face;
 		begin
-			face := to_face (get_field (cmd, 5));
+			unused_face := to_face (get_field (cmd, 5));
 
 			-- CS
 			-- add_zone (

--- a/src/lib/et_cp_board_restrict.adb
+++ b/src/lib/et_cp_board_restrict.adb
@@ -384,9 +384,9 @@ package body et_cp_board_restrict is
 
 
 		procedure do_it is
-			catch_zone : type_catch_zone;
+			unused_catch_zone : type_catch_zone;
 		begin
-			catch_zone := set_catch_zone (
+			unused_catch_zone := set_catch_zone (
 				center	=> to_vector_model (get_field (cmd, 5), get_field (cmd, 6)),
 				radius	=> to_zone_radius (get_field (cmd, 7)));
 

--- a/src/lib/et_directory_and_file_ops.adb
+++ b/src/lib/et_directory_and_file_ops.adb
@@ -56,7 +56,8 @@ package body et_directory_and_file_ops is
 		prefix : constant string := ("$"); -- CS: windows ? (like %home%)
 		separator : constant string := (1 * gnat.directory_operations.dir_separator); -- /\
 		
-		place_prefix, place_separator : natural := 0;
+		place_prefix : natural := 0;
+		unused_place_separator : natural := 0;
 		--use gnat.directory_operations;
 		--use et_string_processing;
 		
@@ -67,7 +68,7 @@ package body et_directory_and_file_ops is
 		
 	begin -- expand
 		place_prefix := index (name_in, prefix);
-		place_separator := index (name_in, separator);
+		unused_place_separator := index (name_in, separator);
 
 		if place_prefix = 0 then -- no environment variable found
 			return name_in; -- return given name as it is

--- a/src/lib/et_geometry_1-et_polygons.adb
+++ b/src/lib/et_geometry_1-et_polygons.adb
@@ -119,7 +119,8 @@ package body et_geometry_1.et_polygons is
 
 		-- In case the mode is EXPAND then this is the
 		-- start and end point of a virtual outer arc:
-		p_start_outside, p_end_outside : type_vector;
+		p_start_outside : type_vector;
+		unused_p_end_outside : type_vector;
 
 		
 		procedure make_edges (p_start : in type_vector) is
@@ -241,7 +242,7 @@ package body et_geometry_1.et_polygons is
 			p_start_outside := move_by (arc_origin.A, arc_angles.angle_start, tolerance_dyn);
 
 			-- The end point of the outer arc:
-			p_end_outside   := move_by (arc_origin.B, arc_angles.angle_end, tolerance_dyn);
+			unused_p_end_outside := move_by (arc_origin.B, arc_angles.angle_end, tolerance_dyn);
 
 			--if debug then
 				--put_line ("start outside : " & to_string (p_start_outside));
@@ -1037,14 +1038,14 @@ package body et_geometry_1.et_polygons is
 
 			procedure query_edge (c : in pac_edges.cursor) is 
 				edge_new : type_edge;
-				cursor_new : pac_edges.cursor;
+				unused_cursor_new : pac_edges.cursor;
 			begin
 				edge_new := reverse_line (element (c));
 				
 				if polygon_new.edges.is_empty then
 					polygon_new.edges.append (edge_new);
 				else
-					cursor_new := polygon_new.edges.first;
+					unused_cursor_new := polygon_new.edges.first;
 					polygon_new.edges.prepend (edge_new);
 				end if;
 			end query_edge;
@@ -3389,7 +3390,7 @@ package body et_geometry_1.et_polygons is
 			return ct;
 		end get_until_begin;
 
-		ct_cw : count_type := 0;
+		unused_ct_cw : count_type := 0;
 
 		
 		
@@ -3464,7 +3465,7 @@ package body et_geometry_1.et_polygons is
 				-- restart the search from the end of the list:
 				if v = pac_vertices.no_element then
 					restart_required := true;
-					ct_cw := get_until_begin;
+					unused_ct_cw := get_until_begin;
 					v := vertices.last;
 					do_collect;
 				end if;

--- a/src/lib/et_geometry_1.adb
+++ b/src/lib/et_geometry_1.adb
@@ -3304,7 +3304,7 @@ package body et_geometry_1 is
 		-- scratch variables:
 		a, b, c, d	: type_float;
 
-		s : type_intersection_status_of_line_and_circle;
+		unused_s : type_intersection_status_of_line_and_circle;
 		intersection_1, intersection_2 : type_vector;
 
 		
@@ -3364,7 +3364,7 @@ package body et_geometry_1 is
 				put_line (" one intersection -> a tangent");
 			end if;
 			
-			s := ONE_EXISTS; -- tangent
+			unused_s := ONE_EXISTS; -- tangent
 
 			x := (DI * dy) / b;
 			y := (-DI * dx) / b;
@@ -3390,7 +3390,7 @@ package body et_geometry_1 is
 				put_line (" no intersection");
 			end if;
 			
-			s := NONE_EXIST;
+			unused_s := NONE_EXIST;
 			
 			return (status => NONE_EXIST);
 
@@ -3403,7 +3403,7 @@ package body et_geometry_1 is
 				put_line (" two intersections -> a secant");
 			end if;
 			
-			s := TWO_EXIST; -- secant
+			unused_s := TWO_EXIST; -- secant
 
 			-- COMPUTE 1ST INTERSECTION:
 			x := ( DI * dy + sgn (dy) * dx * sqrt (d)) / b;

--- a/src/lib/et_kicad-pcb.adb
+++ b/src/lib/et_kicad-pcb.adb
@@ -527,8 +527,8 @@ package body et_kicad.pcb is
 		section_polygon_entered : boolean;
 		
 		-- PACKAGES
-		package_name 			: pac_package_name.bounded_string;
-		package_library_name	: et_kicad_general.type_library_name.bounded_string;
+		unused_package_name 			: pac_package_name.bounded_string;
+		unused_package_library_name	: et_kicad_general.type_library_name.bounded_string;
 		package_position		: et_board_coordinates.type_package_position;
 		
 		-- package_path			: et_kicad.type_timestamp; -- like /59F17F64/59F18F3E/5B852A16/5B851D80
@@ -593,7 +593,7 @@ package body et_kicad.pcb is
 		pad_size_y : type_pad_size;		
 
 		terminal_net_name	: pac_net_name.bounded_string;
-		terminal_net_id		: type_net_id_terminal;
+		unused_terminal_net_id		: type_net_id_terminal;
 	
 -- 		terminal_copper_width_outer_layers : et_board_coordinates.type_distance_model;
 		terminal_copper_width_inner_layers : constant type_distance_positive := 1.0; -- CS load from DRU ?
@@ -1283,8 +1283,8 @@ package body et_kicad.pcb is
 							case section.arg_counter is
 								when 0 => null;
 								when 1 => -- break down something like bel_ic:S_SO14 into package and lib name
-									package_library_name := et_kicad_libraries.library_name (to_string (arg));
-									package_name := et_kicad_libraries.package_name (to_string (arg));
+									unused_package_library_name := et_kicad_libraries.library_name (to_string (arg));
+									unused_package_name := et_kicad_libraries.package_name (to_string (arg));
 									-- CS make sure library and package exist
 								when others => too_many_arguments;
 							end case;
@@ -2030,7 +2030,7 @@ package body et_kicad.pcb is
 						when SEC_NET =>
 							case section.arg_counter is
 								when 0 => null;
-								when 1 => terminal_net_id := to_net_id (to_string (arg));
+								when 1 => unused_terminal_net_id := to_net_id (to_string (arg));
 								when 2 => terminal_net_name := to_net_name (to_string (arg));
 								when others => too_many_arguments;
 							end case;

--- a/src/lib/et_kicad-schematic-read.adb
+++ b/src/lib/et_kicad-schematic-read.adb
@@ -3111,11 +3111,12 @@ is
 						field_value := to_field;
 
 						declare
-							value : pac_device_value.bounded_string;
+							unused_value : pac_device_value.bounded_string;
 						begin
-							value := to_value_with_check (
+							unused_value := to_value_with_check (
 									value 						=> content (field_value),
 									error_on_invalid_character	=> false);
+							null;
 							-- For the operators convenice no error is raised if invalid
 							-- character found. This was the design gets imported but with
 							-- (lots of) warnings.

--- a/src/lib/et_kicad-schematic.adb
+++ b/src/lib/et_kicad-schematic.adb
@@ -7354,7 +7354,7 @@ package body et_kicad.schematic is
 						use pac_terminal_port_map;
 						use pac_port_name;
 						terminal_cursor : pac_terminal_port_map.cursor := variant.terminal_port_map.first;
-						terminal_found : boolean := false;
+						unused_terminal_found : boolean := false;
 					begin
 						-- Search in terminal_port_map for the given port name.
 						-- On first match load the terminal which is a composite of
@@ -7365,7 +7365,7 @@ package body et_kicad.schematic is
 								terminal.unit := element (terminal_cursor).unit; -- to be returned
 								terminal.port := element (terminal_cursor).name; -- to be returned
 								
-								terminal_found := true;
+								unused_terminal_found := true;
 								exit;
 							end if;
 

--- a/src/lib/et_kicad_libraries.adb
+++ b/src/lib/et_kicad_libraries.adb
@@ -1532,8 +1532,8 @@ package body et_kicad_libraries is
 				line : in type_fields_of_line) 
 				return type_symbol_polyline 
 			is
-				polyline	: type_symbol_polyline;
-				total		: positive; -- for cross checking 
+				polyline		: type_symbol_polyline;
+				unused_total	: positive; -- for cross checking 
 
 				-- A polyline is defined by a string like "P 3 0 1 10 0 0 100 50 70 0 N"
 				-- field meaning:
@@ -1558,7 +1558,7 @@ package body et_kicad_libraries is
 			begin -- to_polyline
 
 				-- read total number of points
-				total := positive'value (f (line, pos));
+				unused_total := positive'value (f (line, pos));
 				
 				-- read line width (field #5)
 				pos := 5;
@@ -2093,9 +2093,9 @@ package body et_kicad_libraries is
 					
 					when VALUE =>
 						declare
-							value : pac_device_value.bounded_string;
+							unused_value : pac_device_value.bounded_string;
 						begin
-							value := to_value_with_check (
+							unused_value := to_value_with_check (
 								value 						=> content (text),
 								error_on_invalid_character	=> false);
 							-- For the operators convenice no error is raised if invalid
@@ -2467,7 +2467,7 @@ package body et_kicad_libraries is
 					key		: in pac_unit_name.bounded_string;
 					unit	: in out type_unit_library) is
 					pragma unreferenced (key);
-					pos		: natural := 0; -- helps to trace the program position where an exception occured
+					unused_pos		: natural := 0; -- helps to trace the program position where an exception occured
 				begin
 					case element is
 						when polyline =>
@@ -2486,11 +2486,11 @@ package body et_kicad_libraries is
 							unit.symbol.texts.append (tmp_draw_text);
 
 						when port =>
-							pos := 100;
+							unused_pos := 100;
 							-- CS: test if port not used by other units
-							pos := 110;
+							unused_pos := 110;
 							-- CS: test if pin name not used by other units
-							pos := 190;
+							unused_pos := 190;
 							unit.symbol.ports.append (tmp_draw_port);
 
 							pac_terminal_port_map.insert (

--- a/src/lib/et_module_read_board_zones.adb
+++ b/src/lib/et_module_read_board_zones.adb
@@ -77,7 +77,7 @@ package body et_module_read_board_zones is
 	
 	
 	
-	board_filled : type_filled := filled_default;
+	unused_board_filled : type_filled := filled_default;
 	-- CS rename to zone_filled
 	
 	fill_spacing : type_track_clearance := type_track_clearance'first;
@@ -113,7 +113,7 @@ package body et_module_read_board_zones is
 	
 	procedure reset_scratch is begin
 		fill_spacing		:= type_track_clearance'first;
-		board_filled		:= filled_default;
+		unused_board_filled	:= filled_default;
 		board_fill_style	:= fill_style_default;
 		--board_hatching		:= (others => <>);
 		board_easing 		:= (others => <>);
@@ -143,7 +143,7 @@ package body et_module_read_board_zones is
 		-- CS: In the following: set a corresponding parameter-found-flag
 		if kw = keyword_filled then -- filled yes/no
 			expect_field_count (line, 2);													
-			board_filled := to_filled (f (line, 2));
+			unused_board_filled := to_filled (f (line, 2));
 
 		else
 			invalid_keyword (kw);
@@ -301,7 +301,7 @@ package body et_module_read_board_zones is
 		-- CS: In the following: set a corresponding parameter-found-flag
 		if kw = keyword_filled then -- filled yes/no
 			expect_field_count (line, 2);													
-			board_filled := to_filled (f (line, 2));
+			unused_board_filled := to_filled (f (line, 2));
 
 		elsif kw = keyword_layers then -- layers 1 14 3
 

--- a/src/lib/et_module_read_board_zones_route.adb
+++ b/src/lib/et_module_read_board_zones_route.adb
@@ -69,7 +69,7 @@ package body et_module_read_board_zones_route is
 
 	
 	
-	fill_spacing : type_track_clearance := type_track_clearance'first;
+	unused_fill_spacing : type_track_clearance := type_track_clearance'first;
 	-- CS rename to zone_fill_spacing
 	
 	board_fill_style : type_fill_style := fill_style_default;	
@@ -104,7 +104,7 @@ package body et_module_read_board_zones_route is
 	
 
 	procedure reset_scratch is begin
-		fill_spacing		:= type_track_clearance'first;
+		unused_fill_spacing		:= type_track_clearance'first;
 		board_fill_style	:= fill_style_default;
 		--board_hatching		:= (others => <>);
 		board_easing 		:= (others => <>);
@@ -183,7 +183,7 @@ package body et_module_read_board_zones_route is
 
 		elsif kw = keyword_spacing then -- spacing 1
 			expect_field_count (line, 2);
-			fill_spacing := to_distance (f (line, 2));
+			unused_fill_spacing := to_distance (f (line, 2));
 
 		elsif kw = keyword_layer then -- layer 2
 			expect_field_count (line, 2);

--- a/src/lib/et_net_strands.adb
+++ b/src/lib/et_net_strands.adb
@@ -1698,7 +1698,8 @@ package body et_net_strands is
 		
 		ports_A, ports_B : type_net_ports;
 
-		ports_A_count, ports_B_count : natural;
+		unused_ports_A_count : natural;
+		unused_ports_B_count : natural;
 
 
 		procedure get_segments_and_ports is begin
@@ -1715,8 +1716,8 @@ package body et_net_strands is
 			ports_A := get_ports (segment, A);
 			ports_B := get_ports (segment, B);
 
-			ports_A_count := get_port_count (ports_A);
-			ports_B_count := get_port_count (ports_B);
+			unused_ports_A_count := get_port_count (ports_A);
+			unused_ports_B_count := get_port_count (ports_B);
 		end get_segments_and_ports;
 
 

--- a/src/lib/et_schematic_ops_nets.adb
+++ b/src/lib/et_schematic_ops_nets.adb
@@ -6525,7 +6525,7 @@ package body et_schematic_ops_nets is
 	is
 		result : constant type_net_scope := type_net_scope'first;
 		
-		net_cursor : pac_nets.cursor; -- points to the net
+		unused_net_cursor : pac_nets.cursor; -- points to the net
 	begin
 		log (text => "module " & to_string (module_cursor)
 			& " get scope of net " & to_string (net_name),
@@ -6533,7 +6533,7 @@ package body et_schematic_ops_nets is
 
 
 		-- locate the net
-		net_cursor := locate_net (module_cursor, net_name);
+		unused_net_cursor := locate_net (module_cursor, net_name);
 
 		-- CS
 		-- 	update_element (

--- a/src/lib/et_schematic_ops_submodules.adb
+++ b/src/lib/et_schematic_ops_submodules.adb
@@ -4622,10 +4622,10 @@ package body et_schematic_ops_submodules is
 		-- has been reached:
 		procedure set_offset is 
 			use pac_renumber_modules;
-			module_name 	: pac_module_name.bounded_string; -- motor_driver
-			parent_name 	: pac_module_name.bounded_string; -- water_pump
-			module_range 	: type_index_range;
-			module_instance	: pac_module_instance_name.bounded_string; -- MOT_DRV_3
+			module_name			: pac_module_name.bounded_string; -- motor_driver
+			unused_parent_name	: pac_module_name.bounded_string; -- water_pump
+			module_range		: type_index_range;
+			module_instance		: pac_module_instance_name.bounded_string; -- MOT_DRV_3
 
 			
 			-- Assign the device name offset to the current submodule 
@@ -4660,9 +4660,9 @@ package body et_schematic_ops_submodules is
 
 				-- In case we are on the first level, the parent module is the given top module.				
 				if parent (tree_cursor) = root (submod_tree) then
-					parent_name := autoset_device_name_offsets.module_name;
+					unused_parent_name := autoset_device_name_offsets.module_name;
 				else
-					parent_name := element (parent (tree_cursor)).name;
+					unused_parent_name := element (parent (tree_cursor)).name;
 				end if;
 
 				-- assign the offset to the submodule

--- a/src/lib/et_schematic_ops_units.adb
+++ b/src/lib/et_schematic_ops_units.adb
@@ -973,9 +973,9 @@ package body et_schematic_ops_units is
 		return boolean 
 	is
 		use et_device_renumbering;
-		devices : pac_renumber_devices.map;
+		unused_devices : pac_renumber_devices.map;
 	begin
-		devices := sort_by_coordinates_2 (module_cursor, log_threshold);
+		unused_devices := sort_by_coordinates_2 (module_cursor, log_threshold);
 		-- If a unit sits on top of another unit, sort_by_coordinates_2 throws a
 		-- constraint_error which will be catched here.
 

--- a/src/lib/et_string_processing.adb
+++ b/src/lib/et_string_processing.adb
@@ -211,7 +211,7 @@ package body et_string_processing is
 		IFS2		: constant character := character'val(9); -- field separator tabulator
 		field_ct	: type_field_count := 0; -- field counter (the first field found gets number 1 assigned)
 		field_pt	: natural := 1;			 -- field pointer (points to the charcter being processed inside the current field)
-		inside_field: boolean := true;		 -- true if char_pt points inside a field
+		unused_inside_field: boolean := true;		 -- true if char_pt points inside a field
 		char_current: character;			 -- holds current character being processed
 		char_last	: character := ' ';		 -- holds character processed previous to char_current
 	begin
@@ -220,9 +220,9 @@ package body et_string_processing is
 			--put (char_pt);
 			char_current:= text_in(char_pt); 
 			if char_current = IFS1 or char_current = IFS2 then
-				inside_field := false;
+				unused_inside_field := false;
 			else
-				inside_field := true;
+				unused_inside_field := true;
 			end if;
 
 			-- count fields if character other than IFS found
@@ -377,7 +377,7 @@ package body et_string_processing is
 		subtype type_character_pointer is natural range 0 .. character_count;
 
 		-- Points to character being processed inside the given string:
-		char_pt			: type_character_pointer;		
+		unused_char_pt	: type_character_pointer;		
 
 		-- Field counter (the first field found gets number 1 assigned)
 		field_ct		: type_field_count := 0;	
@@ -395,7 +395,7 @@ package body et_string_processing is
 		--log ("get field from line " & text_in);
 	
 		if character_count > 0 then
-			char_pt := 1;
+			unused_char_pt := 1;
 			for char_pt in 1..character_count loop
 				char_current := text_in(char_pt); 
 				


### PR DESCRIPTION
Variables containing 'unused' in their name are not flagged as unreferenced. 