### PR TITLE
Setup noun depending on verb

### DIFF
--- a/src/lib/et_canvas_board.adb
+++ b/src/lib/et_canvas_board.adb
@@ -859,6 +859,7 @@ package body et_canvas_board is
 	begin
 		put_line ("cb_verb_changed");
 		verb := to_verb (self.get_active_id);
+		set_up_noun_combo;
 	end cb_verb_changed;
 
 	procedure set_up_verb_combo is
@@ -877,12 +878,18 @@ package body et_canvas_board is
 	end set_up_verb_combo;
 
 
+	noun_combo_updating : boolean := false;
+	noun_handler_connected : boolean := false;
 
 	procedure cb_noun_changed (
 		self : access gtk.combo_box.gtk_combo_box_record'class)
 	is
 		use et_modes.board;
 	begin
+		if noun_combo_updating then
+			return;
+		end if;
+
 		put_line ("cb_noun_changed");
 		noun := to_noun (self.get_active_id);
 	end cb_noun_changed;
@@ -890,17 +897,35 @@ package body et_canvas_board is
 	procedure set_up_noun_combo is
 		use et_modes.board;
 		use pac_canvas;
+
+		unused_found : boolean;
 	begin
+		noun_combo_updating := true;
+
+		mode_display.cbox_mode_noun.remove_all;
+
 		for noun in type_noun loop
-			mode_display.cbox_mode_noun.append (
-				id		=> to_string (noun),
-				text	=> to_string (noun));
+			if for_verb (verb).show_noun (noun) then
+				mode_display.cbox_mode_noun.append (
+					id		=> to_string (noun),
+					text	=> to_string (noun));
+			end if;
 		end loop;
 
-		on_changed (
-			mode_display.cbox_mode_noun,
-			call  => cb_noun_changed'access,
-			after => true);
+		unused_found :=
+			mode_display.cbox_mode_noun.set_active_id (
+				active_id	=> to_string (for_verb (verb).activate));
+
+		noun_combo_updating := false;
+
+		if not noun_handler_connected then
+			on_changed (
+				mode_display.cbox_mode_noun,
+				call  => cb_noun_changed'access,
+				after => true);
+
+			noun_handler_connected := true;
+		end if;
 	end set_up_noun_combo;
 
 

--- a/src/lib/et_canvas_schematic.adb
+++ b/src/lib/et_canvas_schematic.adb
@@ -489,6 +489,7 @@ package body et_canvas_schematic is
 	begin
 		put_line ("cb_verb_changed");
 		verb := to_verb (self.get_active_id);
+		set_up_noun_combo;
 	end cb_verb_changed;
 
 	procedure set_up_verb_combo is
@@ -507,12 +508,18 @@ package body et_canvas_schematic is
 	end set_up_verb_combo;
 
 
+	noun_combo_updating : boolean := false;
+	noun_handler_connected : boolean := false;
 
 	procedure cb_noun_changed (
 		self : access gtk.combo_box.gtk_combo_box_record'class)
 	is
 		use et_modes.schematic;
 	begin
+		if noun_combo_updating then
+			return;
+		end if;
+
 		put_line ("cb_noun_changed");
 		noun := to_noun (self.get_active_id);
 	end cb_noun_changed;
@@ -520,17 +527,35 @@ package body et_canvas_schematic is
 	procedure set_up_noun_combo is
 		use et_modes.schematic;
 		use pac_canvas;
+
+		unused_found : boolean;
 	begin
+		noun_combo_updating := true;
+
+		mode_display.cbox_mode_noun.remove_all;
+
 		for noun in type_noun loop
-			mode_display.cbox_mode_noun.append (
-				id		=> to_string (noun),
-				text	=> to_string (noun));
+			if for_verb (verb).show_noun (noun) then
+				mode_display.cbox_mode_noun.append (
+					id		=> to_string (noun),
+					text	=> to_string (noun));
+			end if;
 		end loop;
 
-		on_changed (
-			mode_display.cbox_mode_noun,
-			call  => cb_noun_changed'access,
-			after => true);
+		unused_found :=
+			mode_display.cbox_mode_noun.set_active_id (
+				active_id	=> to_string (for_verb (verb).activate));
+
+		noun_combo_updating := false;
+
+		if not noun_handler_connected then
+			on_changed (
+				mode_display.cbox_mode_noun,
+				call  => cb_noun_changed'access,
+				after => true);
+
+			noun_handler_connected := true;
+		end if;
 	end set_up_noun_combo;
 
 

--- a/src/lib/et_gui_2.adb
+++ b/src/lib/et_gui_2.adb
@@ -153,9 +153,8 @@ package body et_gui_2 is
 		-- Set up special things of the canvas:
 		et_canvas_schematic.set_up_canvas;
 
-		-- Set up verb and noun combo
+		-- Set up noun combo. This calls set_up_noun_combo:
 		set_up_verb_combo;
-		set_up_noun_combo;
 
 		-- Activate the main window:
 		log (text => "show schematic window", level => log_threshold + 1);
@@ -250,9 +249,8 @@ package body et_gui_2 is
 		-- Set up special things of the canvas:
 		et_canvas_board.set_up_canvas;
 
-		-- Set up verb and noun combo
+		-- Set up noun combo. This calls set_up_noun_combo:
 		set_up_verb_combo;
-		set_up_noun_combo;
 
 		-- Activate the main window:
 		log (text => "show board window", level => log_threshold + 1);

--- a/src/lib/et_modes-board.ads
+++ b/src/lib/et_modes-board.ads
@@ -179,6 +179,43 @@ package et_modes.board is
 
 	expect_entry : type_expect_entry := expect_entry_default;
 
+	type type_noun_array_of_boolean is array (type_noun) of boolean;
+
+	type type_verb_for_noun is record
+		show_noun	: type_noun_array_of_boolean;
+		activate	: type_noun;
+	end record
+	with dynamic_predicate =>
+		type_verb_for_noun.show_noun (type_verb_for_noun.activate);
+
+	for_verb : constant array (type_verb) of type_verb_for_noun := (
+		VERB_NONE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ADD		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_DEVICE),
+		VERB_CLEAR		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_COPY		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_VALUE),
+		VERB_DELETE		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_DEVICE),
+		VERB_DEFINE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DISPLAY	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DRAW		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_EXECUTE	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_EXIT		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_FILL		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_FLIP		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MAKE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MOVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_PLACE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_QUIT		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_REMOVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_RENAME		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_RESTORE	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ROUTE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ROTATE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SAVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SET		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SHOW		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_UPDATE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ZOOM		=> ((NOUN_ZOOM => true,								others => false), activate => NOUN_ZOOM));
+
 end et_modes.board;
 
 -- Soli Deo Gloria

--- a/src/lib/et_modes-schematic.ads
+++ b/src/lib/et_modes-schematic.ads
@@ -183,6 +183,51 @@ package et_modes.schematic is
 	expect_entry : type_expect_entry := expect_entry_default;
 
 
+	type type_noun_array_of_boolean is array (type_noun) of boolean;
+
+	type type_verb_for_noun is record
+		show_noun	: type_noun_array_of_boolean;
+		activate	: type_noun;
+	end record
+	with dynamic_predicate =>
+		type_verb_for_noun.show_noun (type_verb_for_noun.activate);
+
+	for_verb : constant array (type_verb) of type_verb_for_noun := (
+		VERB_NONE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ADD		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_DEVICE),
+		VERB_BUILD		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_CHECK		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_CLEAR		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_COPY		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_VALUE),
+		VERB_CREATE		=> ((NOUN_DEVICE | NOUN_MODULE | NOUN_SHEET => true,	others => false), activate => NOUN_SHEET),
+		VERB_DELETE		=> ((NOUN_DEVICE .. NOUN_VALUE => true,				others => false), activate => NOUN_DEVICE),
+		VERB_DESCRIBE	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DEFINE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DISPLAY	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DISSOLVE	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DRAG		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_DRAW		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_EXECUTE	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_EXIT		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_FETCH		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MAKE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MIRROR		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MOVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_MOUNT		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_PASTE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_PLACE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_QUIT		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_REMOVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_RENAME		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_RENUMBER	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ROTATE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SAVE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SET		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_SHOW		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_UNMOUNT	=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_WRITE		=> ((NOUN_NONE => true,								others => false), activate => NOUN_NONE),
+		VERB_ZOOM		=> ((NOUN_ZOOM => true,								others => false), activate => NOUN_ZOOM));
+
 end et_modes.schematic;
 
 -- Soli Deo Gloria


### PR DESCRIPTION
I could not help trying to setup noun depending on verb. A default noun is active depending on the table of constants. Perhaps it should be made such that the active noun should be stored and activated next time the verb is changed. Or something else.

The table needs to be configured. But this requires expert knowledge (hint hint :-)