### PR TITLE
Change renamed function to constant

### DIFF
--- a/src/lib/et_canvas_board-key_pressed.adb
+++ b/src/lib/et_canvas_board-key_pressed.adb
@@ -66,7 +66,7 @@ is
 
 
 
-	point : type_vector_model renames get_cursor_position;
+	point : constant type_vector_model := get_cursor_position;
 
 
 

--- a/src/lib/et_canvas_schematic-key_pressed.adb
+++ b/src/lib/et_canvas_schematic-key_pressed.adb
@@ -61,7 +61,7 @@ is
 	use et_canvas_schematic_group;
 
 
-	point : type_vector_model renames get_cursor_position;
+	point : constant type_vector_model := get_cursor_position;
 
 	-- CS global variable for the tool KEYBOARD
 


### PR DESCRIPTION
The changed lines caused compiler warning. Fix as suggested by compiler.