### PR TITLE
Bash completion: add kicad_v6 to --import-format values

### DIFF
--- a/script/completion.sh
+++ b/script/completion.sh
@@ -60,7 +60,7 @@ _et_completion () {
 			;;
 
 		--import-format)
-			COMPREPLY=( $(compgen -W "kicad_v4 kicad_v5" -- "${cur}") )
+			COMPREPLY=( $(compgen -W "kicad_v4 kicad_v5 kicad_v6" -- "${cur}") )
 			return 0
 			;;
 


### PR DESCRIPTION
et_import.type_cad_format has had KICAD_V6 for a while now (this whole feature), but the completion script's --import-format value list was never updated to match -- tab-completion still only offered kicad_v4/kicad_v5.