### PR TITLE
Use generic iterators for doubly linked lists

### DIFF
--- a/src/lib/et_assy_doc.adb
+++ b/src/lib/et_assy_doc.adb
@@ -63,23 +63,6 @@ package body et_assy_doc is
 
 
 
-	procedure iterate (
-		lines	: in type_doc_line_list;
-		process	: not null access procedure (position : in type_doc_line_cursor);
-		proceed	: not null access boolean)
-	is
-		use pac_doc_lines;
-
-		c : type_doc_line_cursor := lines.first;
-	begin
-		while c /= pac_doc_lines.no_element and proceed.all = TRUE loop
-			process (c);
-			next (c);
-		end loop;
-	end iterate;
-
-
-
 	function is_proposed (
 		line_cursor	: in type_doc_line_cursor)
 		return boolean
@@ -185,25 +168,6 @@ package body et_assy_doc is
 		reset_arc (type_arc (arc));
 		arc.width := linewidth_default;
 	end reset_arc;
-
-
-
-	procedure iterate (
-		arcs	: in type_doc_arc_list;
-		process	: not null access procedure (position : in type_doc_arc_cursor);
-		proceed	: not null access boolean)
-	is
-		use pac_doc_arcs;
-
-		c : type_doc_arc_cursor := arcs.first;
-	begin
-		while c /= pac_doc_arcs.no_element and proceed.all = TRUE loop
-			process (c);
-			next (c);
-		end loop;
-	end iterate;
-
-
 
 
 
@@ -510,22 +474,6 @@ package body et_assy_doc is
 		return string
 	is (to_string (element (text)));
 
-
-
-
-
-	procedure iterate (
-		texts	: in pac_doc_texts.list;
-		process	: not null access procedure (position : in pac_doc_texts.cursor);
-		proceed	: not null access boolean)
-	is
-		c : pac_doc_texts.cursor := texts.first;
-	begin
-		while c /= pac_doc_texts.no_element and proceed.all = TRUE loop
-			process (c);
-			next (c);
-		end loop;
-	end iterate;
 
 
 

--- a/src/lib/et_assy_doc.ads
+++ b/src/lib/et_assy_doc.ads
@@ -81,12 +81,6 @@ package et_assy_doc is
 	subtype type_doc_line_cursor	is pac_doc_lines.cursor;
 
 
-	-- Iterates the lines.
-	-- Aborts the process when the proceed-flag goes false:
-	procedure iterate (
-		lines	: in type_doc_line_list;
-		process	: not null access procedure (position : in type_doc_line_cursor);
-		proceed	: not null access boolean);
 
 	-- CS likewise iteratator for circles
 
@@ -138,14 +132,6 @@ package et_assy_doc is
 
 	subtype type_doc_arc_list	is pac_doc_arcs.list;
 	subtype type_doc_arc_cursor	is pac_doc_arcs.cursor;
-
-
-	-- Iterates the arcs
-	-- Aborts the process when the proceed-flag goes false:
-	procedure iterate (
-		arcs	: in type_doc_arc_list;
-		process	: not null access procedure (position : in type_doc_arc_cursor);
-		proceed	: not null access boolean);
 
 
 
@@ -291,15 +277,6 @@ package et_assy_doc is
 	function to_string (
 		text : in pac_doc_texts.cursor)
 		return string;
-
-
-	-- Iterates the texts.
-	-- Aborts the process when the proceed-flag goes false:
-	procedure iterate (
-		texts	: in pac_doc_texts.list;
-		process	: not null access procedure (position : in pac_doc_texts.cursor);
-		proceed	: not null access boolean);
-
 
 
 	-- Mirrors a list of texts along the given axis:

--- a/src/lib/et_board_ops_assy_doc.adb
+++ b/src/lib/et_board_ops_assy_doc.adb
@@ -39,6 +39,8 @@
 
 -- with ada.text_io;			use ada.text_io;
 with ada.containers.doubly_linked_lists;
+
+with et_help_doubly_linked_lists;
 with et_string_processing;				use et_string_processing;
 with et_text_content;
 with et_pcb_placeholders;
@@ -439,13 +441,15 @@ package body et_board_ops_assy_doc is
 			module		: in type_generic_module)
 		is
 			pragma unreferenced (module_name);
-			proceed : aliased boolean := true;
 
 			top_items		: pac_doc_lines.list renames module.board.assy_doc.top.lines;
 			bottom_items	: pac_doc_lines.list renames module.board.assy_doc.bottom.lines;
 
 
-			procedure query_line (c : in pac_doc_lines.cursor) is begin
+			procedure query_line (c : in pac_doc_lines.cursor; proceed : out boolean) is
+			begin
+				proceed := true;
+
 				case flag is
 					when PROPOSED =>
 						if is_proposed (c) then
@@ -464,16 +468,20 @@ package body et_board_ops_assy_doc is
 				end case;
 			end query_line;
 
+			procedure iterate_query_line is
+			new et_help_doubly_linked_lists.iterate_with_proceed (
+				pac_list	=> pac_doc_lines,
+				process		=> query_line);
 
-
+			proceed : boolean;
 		begin
 			-- Query the lines in the top layer first:
-			iterate (top_items, query_line'access, proceed'access);
+			iterate_query_line (top_items, proceed);
 			result.face := top;
 
 			-- If nothing found, then query the bottom layer:
 			if proceed then
-				iterate (bottom_items, query_line'access, proceed'access);
+				iterate_query_line (bottom_items, proceed);
 				result.face := bottom;
 			end if;
 
@@ -1118,13 +1126,15 @@ package body et_board_ops_assy_doc is
 			module		: in type_generic_module)
 		is
 			pragma unreferenced (module_name);
-			proceed : aliased boolean := true;
 
 			top_items		: pac_doc_arcs.list renames module.board.assy_doc.top.arcs;
 			bottom_items	: pac_doc_arcs.list renames module.board.assy_doc.bottom.arcs;
 
 
-			procedure query_arc (c : in pac_doc_arcs.cursor) is begin
+			procedure query_arc (c : in pac_doc_arcs.cursor; proceed : out boolean) is
+			begin
+				proceed := true;
+
 				case flag is
 					when PROPOSED =>
 						if is_proposed (c) then
@@ -1144,15 +1154,20 @@ package body et_board_ops_assy_doc is
 			end query_arc;
 
 
+			procedure iterate_query_arc is
+			new et_help_doubly_linked_lists.iterate_with_proceed (
+				pac_list	=> pac_doc_arcs,
+				process		=> query_arc);
 
+			proceed : boolean;
 		begin
 			-- Query the arcs in the top layer first:
-			iterate (top_items, query_arc'access, proceed'access);
+			iterate_query_arc (top_items, proceed);
 			result.face := top;
 
 			-- If nothing found, then query the bottom layer:
 			if proceed then
-				iterate (bottom_items, query_arc'access, proceed'access);
+				iterate_query_arc (bottom_items, proceed);
 				result.face := bottom;
 			end if;
 
@@ -2818,13 +2833,14 @@ package body et_board_ops_assy_doc is
 			pragma unreferenced (module_name);
 			use pac_doc_texts;
 
-			proceed : aliased boolean := true;
-
 			top_items		: pac_doc_texts.list renames module.board.assy_doc.top.texts;
 			bottom_items	: pac_doc_texts.list renames module.board.assy_doc.bottom.texts;
 
 
-			procedure query_text (c : in pac_doc_texts.cursor) is begin
+			procedure query_text (c : in pac_doc_texts.cursor; proceed : out boolean) is
+			begin
+				proceed := true;
+
 				case flag is
 					when PROPOSED =>
 						if is_proposed (c) then
@@ -2843,15 +2859,20 @@ package body et_board_ops_assy_doc is
 				end case;
 			end query_text;
 
+			procedure iterate_query_text is
+			new et_help_doubly_linked_lists.iterate_with_proceed (
+				pac_list	=> pac_doc_texts,
+				process		=> query_text);
 
+			proceed : boolean;
 		begin
 			-- Query the texts in the top layer first:
-			iterate (top_items, query_text'access, proceed'access);
+			iterate_query_text (top_items, proceed);
 			result.face := top;
 
 			-- If nothing found, then query the bottom layer:
 			if proceed then
-				iterate (bottom_items, query_text'access, proceed'access);
+				iterate_query_text (bottom_items, proceed);
 				result.face := bottom;
 			end if;
 

--- a/src/lib/et_help_doubly_linked_lists.adb
+++ b/src/lib/et_help_doubly_linked_lists.adb
@@ -1,0 +1,36 @@
+
+
+package body et_help_doubly_linked_lists is
+
+	-----------------
+	-- iterate_all --
+	-----------------
+
+	procedure iterate_all (
+		list : in pac_list.list)
+	is
+	begin
+		for item in list.iterate loop
+			process (item);
+		end loop;
+	end iterate_all;
+
+	--------------------------
+	-- iterate_with_proceed --
+	--------------------------
+
+	procedure iterate_with_proceed (
+		list	: in pac_list.list;
+		proceed	: out boolean)
+	is
+	begin
+		proceed := true;
+
+		for item in list.iterate loop
+			process (item, proceed);
+			exit when not proceed;
+		end loop;
+	end iterate_with_proceed;
+
+end et_help_doubly_linked_lists;
+

--- a/src/lib/et_help_doubly_linked_lists.ads
+++ b/src/lib/et_help_doubly_linked_lists.ads
@@ -1,0 +1,19 @@
+
+
+with ada.containers.doubly_linked_lists;
+
+package et_help_doubly_linked_lists is
+
+	generic
+		with package pac_list is new ada.containers.doubly_linked_lists (<>);
+		with procedure process (item : in pac_list.cursor);
+	procedure iterate_all (list : in pac_list.list);
+
+	generic
+		with package pac_list is new ada.containers.doubly_linked_lists (<>);
+		with procedure process (list : in pac_list.cursor; proceed : out boolean);
+	procedure iterate_with_proceed (list : in pac_list.list; proceed : out boolean);
+	-- Iterate all elements of List with Process or until Proceed goes False.
+
+end et_help_doubly_linked_lists;
+


### PR DESCRIPTION
What do you think of this construct?

There are a lot of `iterate` procedures which follow the same pattern.
This replaces these procedures with local generic instantiations.

Benefits:
- Reduce code
- Reduce use of `'access`
- Improve readability. No 'hidden' aliased proceed flag.

Drawbacks:
- Add `proceed` parameter to process function.
